### PR TITLE
Refactor competences page data and controls

### DIFF
--- a/competences.html
+++ b/competences.html
@@ -253,6 +253,12 @@
             transition: opacity 0.18s ease, transform 0.18s ease;
         }
 
+        .skills-placeholder {
+            justify-content: center;
+            font-style: italic;
+            color: var(--color-gray-700);
+        }
+
         .skills-line {
             display: flex;
             align-items: center;
@@ -314,6 +320,37 @@
             transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
         }
 
+        .skills-value-group {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--space-2);
+            margin-left: auto;
+        }
+
+        .skill-point-btn {
+            width: 28px;
+            height: 28px;
+            border-radius: var(--radius-sm);
+            border: 1px solid #c7ccd6;
+            background: linear-gradient(to bottom, #ffffff, #ccd3e0);
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: var(--text-sm);
+            padding: 0;
+            color: #343a46;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+            transition: all 0.12s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        .skill-point-btn:disabled,
+        .skills-points-btn:disabled {
+            cursor: not-allowed;
+            opacity: 0.6;
+            box-shadow: none;
+        }
+
         .skills-line:hover .skills-value {
             background: linear-gradient(135deg, #5a6678, #3d4858);
             transform: scale(1.05);
@@ -328,6 +365,37 @@
         .skills-fade-in {
             opacity: 1;
             transform: translateY(0);
+        }
+
+        .skills-actions {
+            display: flex;
+            align-items: center;
+            gap: var(--space-3);
+            margin-top: var(--space-4);
+        }
+
+        .skills-confirm-btn {
+            padding: var(--space-2) var(--space-4);
+            border-radius: var(--radius-md);
+            border: 1px solid var(--color-primary);
+            background: var(--color-primary-lighter);
+            color: var(--color-primary-dark);
+            cursor: pointer;
+            font-weight: var(--font-medium);
+            transition: all 0.12s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        .skills-confirm-btn:disabled,
+        .skills-confirm-btn.is-locked {
+            background: #e1e4ec;
+            color: var(--color-gray-700);
+            cursor: not-allowed;
+            border-color: #c7ccd6;
+        }
+
+        .skills-validation {
+            font-size: var(--text-sm);
+            color: var(--color-primary-dark);
         }
 
         /* Polish général */
@@ -383,16 +451,17 @@
         }
     </style>
 </head>
+
 <body>
     <div class="skills-page">
         <header class="skills-header">
             <h1 class="skills-title">Feuille de compétences</h1>
-            <a href="index.html" class="skills-back-link">← Retour</a>
+            <a href="categories.html" class="skills-back-link">← Retour</a>
         </header>
 
         <section class="skills-layout" aria-label="Feuille de compétences">
             <!-- Colonne de gauche : onglets ronds -->
-            <aside class="skills-sidebar" id="skillsTabs" aria-label="Catégories de compétences">
+            <aside class="skills-sidebar" id="skillsTabs" aria-label="Catégories de compétences" role="navigation">
                 <!-- Boutons générés par JavaScript -->
             </aside>
 
@@ -401,7 +470,7 @@
                 <div class="skills-panel-header">
                     <h2 class="skills-panel-title" id="skillsCategoryTitle">Catégorie</h2>
 
-                    <div class="skills-points-box" aria-label="Points à répartir">
+                    <div class="skills-points-box" aria-label="Points à répartir" role="status" aria-live="polite">
                         <span class="skills-points-label">Points à répartir :</span>
                         <button type="button" class="skills-points-btn" id="skillsPointsMinus" aria-label="Retirer un point">
                             −
@@ -410,253 +479,25 @@
                         <button type="button" class="skills-points-btn" id="skillsPointsPlus" aria-label="Ajouter un point">
                             +
                         </button>
+                        <button type="button" class="skills-points-btn" id="skillsPointsReset" aria-label="Réinitialiser les points de la catégorie">
+                            ↺
+                        </button>
                     </div>
                 </div>
 
                 <ul class="skills-list" id="skillsList">
                     <!-- Lignes de compétences injectées par JavaScript -->
                 </ul>
+
+                <div class="skills-actions">
+                    <button type="button" class="skills-confirm-btn" id="skillsConfirmBtn">Valider mes points</button>
+                    <div class="skills-validation" id="skillsValidationFeedback" role="status" aria-live="polite"></div>
+                </div>
             </main>
         </section>
     </div>
 
-    <script>
-        // =====================================================================
-        // Données : adapte ici les catégories et compétences à ton système
-        // =====================================================================
-        const skillsCategories = [
-            {
-                id: "arts",
-                label: "Arts",
-                icon: '<img src="assets/images/Bouton_1_Competences.png" alt="Arts">',
-                skills: [
-                    { name: "Peinture", value: 12, icon: "🖌️" },
-                    { name: "Musique", value: 8, icon: "🎵" },
-                    { name: "Théâtre", value: 6, icon: "🎭" },
-                    { name: "Écriture créative", value: 10, icon: "✍️" },
-                    { name: "Danse", value: 5, icon: "💃" }
-                ]
-            },
-            {
-                id: "connaissances",
-                label: "Connaissances",
-                icon: '<img src="assets/images/Bouton_2_Competences.png" alt="Connaissances">',
-                skills: [
-                    { name: "Histoire", value: 9, icon: "📜" },
-                    { name: "Arcane & Théorie", value: 7, icon: "🔮" },
-                    { name: "Linguistique", value: 11, icon: "🗣️" },
-                    { name: "Religion & Mythes", value: 5, icon: "⛪" },
-                    { name: "Investigation", value: 8, icon: "🔍" }
-                ]
-            },
-            {
-                id: "combat",
-                label: "Combat",
-                icon: '<img src="assets/images/Bouton_3_Competences.png" alt="Combat">',
-                skills: [
-                    { name: "Maniement des armes", value: 13, icon: "🗡️" },
-                    { name: "Parade", value: 7, icon: "🛡️" },
-                    { name: "Esquive", value: 10, icon: "💨" },
-                    { name: "Résistance physique", value: 6, icon: "💪" },
-                    { name: "Tactique de groupe", value: 4, icon: "👥" }
-                ]
-            },
-            {
-                id: "pouvoirs",
-                label: "Pouvoirs",
-                icon: '<img src="assets/images/Bouton_4_Competences.png" alt="Pouvoirs">',
-                skills: [
-                    { name: "Contrôle d'Alice", value: 15, icon: "🌟" },
-                    { name: "Synchronisation Meister", value: 9, icon: "🔗" },
-                    { name: "Maîtrise d'arme", value: 11, icon: "⚡" },
-                    { name: "Déchaînement contrôlé", value: 5, icon: "💥" },
-                    { name: "Stabilité mentale", value: 7, icon: "🧠" }
-                ]
-            },
-            {
-                id: "social",
-                label: "Social",
-                icon: '<img src="assets/images/Bouton_5_Competences.png" alt="Social">',
-                skills: [
-                    { name: "Persuasion", value: 10, icon: "🎯" },
-                    { name: "Intimidation", value: 6, icon: "😠" },
-                    { name: "Empathie", value: 9, icon: "❤️" },
-                    { name: "Négociation", value: 7, icon: "🤝" },
-                    { name: "Tromperie", value: 4, icon: "🎭" }
-                ]
-            },
-            {
-                id: "artisanat",
-                label: "Artisanat",
-                icon: '<img src="assets/images/Bouton_6_Competences.png" alt="Artisanat">',
-                skills: [
-                    { name: "Forge & Métallurgie", value: 6, icon: "⚒️" },
-                    { name: "Alchimie", value: 8, icon: "⚗️" },
-                    { name: "Ingénierie", value: 5, icon: "⚙️" },
-                    { name: "Couture & Tissage", value: 7, icon: "🧵" },
-                    { name: "Cuisine", value: 9, icon: "🍳" }
-                ]
-            },
-            {
-                id: "nature",
-                label: "Nature",
-                icon: '<img src="assets/images/Bouton_7_Competences.png" alt="Nature">',
-                skills: [
-                    { name: "Orientation", value: 7, icon: "🧭" },
-                    { name: "Pistage", value: 6, icon: "👣" },
-                    { name: "Herboristerie", value: 8, icon: "🌿" },
-                    { name: "Survie en milieu hostile", value: 9, icon: "🏕️" },
-                    { name: "Discrétion", value: 5, icon: "🥷" }
-                ]
-            },
-            {
-                id: "physique",
-                label: "Physique",
-                icon: '<img src="assets/images/Bouton_8_Competences.png" alt="Physique">',
-                skills: [
-                    { name: "Force brute", value: 10, icon: "🏋️" },
-                    { name: "Agilité", value: 11, icon: "🤸" },
-                    { name: "Endurance", value: 9, icon: "🏃" },
-                    { name: "Réflexes", value: 8, icon: "⚡" },
-                    { name: "Athlétisme", value: 7, icon: "🏅" }
-                ]
-            },
-            {
-                id: "reputation",
-                label: "Réputation",
-                icon: '<img src="assets/images/Bouton_9_Competences.png" alt="Réputation">',
-                skills: [
-                    { name: "Renommée", value: 6, icon: "⭐" },
-                    { name: "Contacts", value: 8, icon: "📞" },
-                    { name: "Marchandage", value: 10, icon: "💰" },
-                    { name: "Crédit social", value: 5, icon: "📈" },
-                    { name: "Influence politique", value: 4, icon: "🏛️" }
-                ]
-            }
-        ];
-
-        // État simple
-        const skillsState = {
-            activeCategoryId: skillsCategories[0].id,
-            points: 0
-        };
-
-        const skillsTabsContainer = document.getElementById("skillsTabs");
-        const skillsTitleEl = document.getElementById("skillsCategoryTitle");
-        const skillsListEl = document.getElementById("skillsList");
-        const skillsPointsValueEl = document.getElementById("skillsPointsValue");
-        const skillsPointsPlusEl = document.getElementById("skillsPointsPlus");
-        const skillsPointsMinusEl = document.getElementById("skillsPointsMinus");
-
-        // -----------------------------------------------------------------
-        // Génération des onglets à partir des données
-        // -----------------------------------------------------------------
-        function renderSkillsTabs() {
-            skillsTabsContainer.innerHTML = "";
-
-            skillsCategories.forEach((category) => {
-                const btn = document.createElement("button");
-                btn.type = "button";
-                btn.className = "skills-tab-btn";
-                btn.dataset.id = category.id;
-                btn.title = category.label;
-                btn.setAttribute("aria-label", category.label);
-
-                btn.innerHTML = `
-                    <span class="skills-tab-circle">${category.icon}</span>
-                    <span class="skills-tab-label">${category.label}</span>
-                `;
-
-                if (category.id === skillsState.activeCategoryId) {
-                    btn.classList.add("skills-active");
-                }
-
-                btn.addEventListener("click", () => setActiveSkillsCategory(category.id));
-
-                skillsTabsContainer.appendChild(btn);
-            });
-        }
-
-        // -----------------------------------------------------------------
-        // Rendu de la catégorie sélectionnée (titre + liste)
-        // -----------------------------------------------------------------
-        function renderSkillsCategory(category) {
-            if (!category) return;
-
-            skillsTitleEl.classList.add("skills-fade-out");
-            skillsListEl.classList.add("skills-fade-out");
-
-            setTimeout(() => {
-                skillsTitleEl.textContent = category.label;
-
-                skillsListEl.innerHTML = "";
-                category.skills.forEach((skill) => {
-                    const li = document.createElement("li");
-                    li.className = "skills-line";
-                    li.innerHTML = `
-                        <div class="skills-icon" aria-hidden="true">${skill.icon || ''}</div>
-                        <div class="skills-name">${skill.name}</div>
-                        <div class="skills-value">${skill.value}</div>
-                    `;
-                    skillsListEl.appendChild(li);
-                });
-
-                skillsTitleEl.classList.remove("skills-fade-out");
-                skillsListEl.classList.remove("skills-fade-out");
-                skillsTitleEl.classList.add("skills-fade-in");
-                skillsListEl.classList.add("skills-fade-in");
-
-                setTimeout(() => {
-                    skillsTitleEl.classList.remove("skills-fade-in");
-                    skillsListEl.classList.remove("skills-fade-in");
-                }, 180);
-            }, 140);
-        }
-
-        // -----------------------------------------------------------------
-        // Changement d'onglet
-        // -----------------------------------------------------------------
-        function setActiveSkillsCategory(categoryId) {
-            if (skillsState.activeCategoryId === categoryId) return;
-
-            skillsState.activeCategoryId = categoryId;
-
-            document.querySelectorAll(".skills-tab-btn").forEach((btn) => {
-                btn.classList.toggle("skills-active", btn.dataset.id === categoryId);
-            });
-
-            const category = skillsCategories.find((c) => c.id === categoryId);
-            renderSkillsCategory(category);
-        }
-
-        // -----------------------------------------------------------------
-        // Gestion des points à répartir
-        // -----------------------------------------------------------------
-        function updateSkillsPointsDisplay() {
-            skillsPointsValueEl.textContent = skillsState.points;
-        }
-
-        skillsPointsPlusEl.addEventListener("click", () => {
-            if (skillsState.points < 99) {
-                skillsState.points += 1;
-                updateSkillsPointsDisplay();
-            }
-        });
-
-        skillsPointsMinusEl.addEventListener("click", () => {
-            if (skillsState.points > 0) {
-                skillsState.points -= 1;
-                updateSkillsPointsDisplay();
-            }
-        });
-
-        // -----------------------------------------------------------------
-        // Initialisation
-        // -----------------------------------------------------------------
-        renderSkillsTabs();
-        renderSkillsCategory(skillsCategories[0]);
-        updateSkillsPointsDisplay();
-    </script>
+    <script src="data.js" defer></script>
+    <script src="competences.js" defer></script>
 </body>
 </html>
-

--- a/competences.js
+++ b/competences.js
@@ -1,0 +1,366 @@
+(function () {
+    const skillsTabsContainer = document.getElementById("skillsTabs");
+    const skillsTitleEl = document.getElementById("skillsCategoryTitle");
+    const skillsListEl = document.getElementById("skillsList");
+    const skillsPointsValueEl = document.getElementById("skillsPointsValue");
+    const skillsPointsMinusEl = document.getElementById("skillsPointsMinus");
+    const skillsPointsPlusEl = document.getElementById("skillsPointsPlus");
+    const skillsPointsResetEl = document.getElementById("skillsPointsReset");
+    const skillsConfirmEl = document.getElementById("skillsConfirmBtn");
+    const skillsFeedbackEl = document.getElementById("skillsValidationFeedback");
+
+    const skillsCategories = Array.isArray(window.skillsCategories)
+        ? window.skillsCategories
+        : [];
+
+    const skillsStorageKey = "skillsPointsByCategory";
+    const skillsAllocStorageKey = "skillsAllocationsByCategory";
+
+    const skillsState = {
+        activeCategoryId: skillsCategories[0]?.id || "",
+        pointsByCategory: loadFromStorage(skillsStorageKey),
+        allocationsByCategory: loadFromStorage(skillsAllocStorageKey),
+        locksByCategory: {},
+        isAdmin: document.body.dataset.admin === "true" || !document.body.hasAttribute("data-admin")
+    };
+
+    // Placeholder minimal pour l'état de chargement
+    addLoadingPlaceholder();
+
+    if (!skillsCategories.length) {
+        renderEmptyMessage("Aucune compétence disponible");
+        return;
+    }
+
+    renderSkillsTabs();
+    renderSkillsCategory(getActiveCategory());
+    updateSkillsPointsDisplay();
+    wireTabsKeyboardNavigation();
+
+    // -----------------------------------------------------------------
+    // Helpers de stockage
+    // -----------------------------------------------------------------
+    function loadFromStorage(key) {
+        try {
+            const raw = localStorage.getItem(key);
+            return raw ? JSON.parse(raw) : {};
+        } catch (error) {
+            console.warn("Impossible de charger", key, error);
+            return {};
+        }
+    }
+
+    function saveToStorage(key, value) {
+        try {
+            localStorage.setItem(key, JSON.stringify(value));
+        } catch (error) {
+            console.warn("Impossible d'enregistrer", key, error);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Accès aux données
+    // -----------------------------------------------------------------
+    function getActiveCategory() {
+        return skillsCategories.find((category) => category.id === skillsState.activeCategoryId);
+    }
+
+    function getCategoryAllocations(categoryId) {
+        if (!skillsState.allocationsByCategory[categoryId]) {
+            skillsState.allocationsByCategory[categoryId] = {};
+        }
+        return skillsState.allocationsByCategory[categoryId];
+    }
+
+    function getCurrentCategoryPoints() {
+        const id = skillsState.activeCategoryId;
+        return skillsState.pointsByCategory[id] ?? 0;
+    }
+
+    function setCurrentCategoryPoints(value) {
+        skillsState.pointsByCategory[skillsState.activeCategoryId] = Math.max(0, value);
+        saveToStorage(skillsStorageKey, skillsState.pointsByCategory);
+    }
+
+    // -----------------------------------------------------------------
+    // Rendu des onglets
+    // -----------------------------------------------------------------
+    function renderSkillsTabs() {
+        skillsTabsContainer.innerHTML = "";
+        skillsTabsContainer.setAttribute("role", "tablist");
+
+        skillsCategories.forEach((category, index) => {
+            const btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "skills-tab-btn";
+            btn.dataset.id = category.id;
+            btn.title = category.label;
+            btn.setAttribute("role", "tab");
+            btn.setAttribute("aria-selected", category.id === skillsState.activeCategoryId ? "true" : "false");
+            btn.tabIndex = category.id === skillsState.activeCategoryId ? 0 : -1;
+
+            const circle = document.createElement("span");
+            circle.className = "skills-tab-circle";
+            const img = document.createElement("img");
+            img.src = category.icon?.src || "";
+            img.alt = category.icon?.alt || category.label;
+            circle.appendChild(img);
+
+            const label = document.createElement("span");
+            label.className = "skills-tab-label";
+            label.textContent = category.label;
+
+            btn.append(circle, label);
+
+            if (category.id === skillsState.activeCategoryId) {
+                btn.classList.add("skills-active");
+            }
+
+            btn.addEventListener("click", () => setActiveSkillsCategory(category.id));
+
+            skillsTabsContainer.appendChild(btn);
+        });
+    }
+
+    function wireTabsKeyboardNavigation() {
+        skillsTabsContainer.addEventListener("keydown", (event) => {
+            const tabs = Array.from(skillsTabsContainer.querySelectorAll("[role='tab']"));
+            const currentIndex = tabs.findIndex((tab) => tab.dataset.id === skillsState.activeCategoryId);
+            if (currentIndex === -1) return;
+
+            let nextIndex = currentIndex;
+            if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+                nextIndex = (currentIndex + 1) % tabs.length;
+            } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+                nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+            } else if (event.key === "Home") {
+                nextIndex = 0;
+            } else if (event.key === "End") {
+                nextIndex = tabs.length - 1;
+            } else if (event.key === " " || event.key === "Enter") {
+                setActiveSkillsCategory(skillsState.activeCategoryId);
+                return;
+            } else {
+                return;
+            }
+
+            event.preventDefault();
+            const nextTab = tabs[nextIndex];
+            setActiveSkillsCategory(nextTab.dataset.id);
+            nextTab.focus();
+        });
+    }
+
+    // -----------------------------------------------------------------
+    // Rendu catégorie
+    // -----------------------------------------------------------------
+    function renderSkillsCategory(category) {
+        if (!category) {
+            renderEmptyMessage("Aucune compétence disponible");
+            return;
+        }
+
+        skillsTitleEl.textContent = category.label;
+        skillsListEl.innerHTML = "";
+        const allocations = getCategoryAllocations(category.id);
+        const isLocked = Boolean(skillsState.locksByCategory[category.id]);
+
+        if (!category.skills || !category.skills.length) {
+            renderEmptyMessage("Aucune compétence dans cette catégorie");
+            return;
+        }
+
+        category.skills.forEach((skill) => {
+            const allocation = allocations[skill.name] || 0;
+            const totalValue = (skill.baseValue ?? skill.value ?? 0) + allocation;
+            const li = document.createElement("li");
+            li.className = "skills-line";
+
+            const icon = document.createElement("div");
+            icon.className = "skills-icon";
+            icon.setAttribute("aria-hidden", "true");
+            icon.textContent = skill.icon || "";
+
+            const name = document.createElement("div");
+            name.className = "skills-name";
+            name.textContent = skill.name;
+
+            const controls = document.createElement("div");
+            controls.className = "skills-value-group";
+
+            const decBtn = document.createElement("button");
+            decBtn.type = "button";
+            decBtn.className = "skill-point-btn";
+            decBtn.textContent = "−";
+            decBtn.setAttribute("aria-label", `Retirer un point sur ${skill.name}`);
+            decBtn.disabled = allocation <= 0 || isLocked;
+
+            const value = document.createElement("span");
+            value.className = "skills-value";
+            value.textContent = totalValue;
+
+            const incBtn = document.createElement("button");
+            incBtn.type = "button";
+            incBtn.className = "skill-point-btn";
+            incBtn.textContent = "+";
+            incBtn.setAttribute("aria-label", `Ajouter un point sur ${skill.name}`);
+            incBtn.disabled = getCurrentCategoryPoints() <= 0 || isLocked;
+
+            decBtn.addEventListener("click", () => {
+                adjustSkillPoints(category.id, skill, -1, value, decBtn, incBtn);
+            });
+            incBtn.addEventListener("click", () => {
+                adjustSkillPoints(category.id, skill, 1, value, decBtn, incBtn);
+            });
+
+            controls.append(decBtn, value, incBtn);
+            li.append(icon, name, controls);
+            skillsListEl.appendChild(li);
+        });
+
+        updateSkillsPointsDisplay();
+        updateLockState(isLocked);
+    }
+
+    function adjustSkillPoints(categoryId, skill, delta, valueEl, decBtn, incBtn) {
+        if (skillsState.locksByCategory[categoryId]) return;
+
+        const allocations = getCategoryAllocations(categoryId);
+        const currentAlloc = allocations[skill.name] || 0;
+        const available = skillsState.pointsByCategory[categoryId] ?? 0;
+
+        if (delta > 0 && available <= 0) return;
+        if (delta < 0 && currentAlloc <= 0) return;
+
+        const nextAlloc = Math.max(0, currentAlloc + delta);
+        const base = skill.baseValue ?? skill.value ?? 0;
+
+        allocations[skill.name] = nextAlloc;
+        skillsState.pointsByCategory[categoryId] = Math.max(0, available - delta);
+        saveToStorage(skillsAllocStorageKey, skillsState.allocationsByCategory);
+        saveToStorage(skillsStorageKey, skillsState.pointsByCategory);
+
+        valueEl.textContent = base + nextAlloc;
+        decBtn.disabled = nextAlloc <= 0 || skillsState.locksByCategory[categoryId];
+        incBtn.disabled = (skillsState.pointsByCategory[categoryId] ?? 0) <= 0 || skillsState.locksByCategory[categoryId];
+
+        updateSkillsPointsDisplay();
+    }
+
+    function renderEmptyMessage(message) {
+        skillsListEl.innerHTML = "";
+        const li = document.createElement("li");
+        li.className = "skills-line skills-placeholder";
+        li.textContent = message;
+        skillsListEl.appendChild(li);
+    }
+
+    function addLoadingPlaceholder() {
+        if (!skillsListEl) return;
+        const li = document.createElement("li");
+        li.className = "skills-line skills-placeholder";
+        li.textContent = "Chargement...";
+        skillsListEl.appendChild(li);
+    }
+
+    // -----------------------------------------------------------------
+    // Changement d'onglet
+    // -----------------------------------------------------------------
+    function setActiveSkillsCategory(categoryId) {
+        if (skillsState.activeCategoryId === categoryId) return;
+
+        skillsState.activeCategoryId = categoryId;
+
+        document.querySelectorAll(".skills-tab-btn").forEach((btn) => {
+            const isActive = btn.dataset.id === categoryId;
+            btn.classList.toggle("skills-active", isActive);
+            btn.setAttribute("aria-selected", isActive ? "true" : "false");
+            btn.tabIndex = isActive ? 0 : -1;
+        });
+
+        const category = skillsCategories.find((c) => c.id === categoryId);
+        renderSkillsCategory(category);
+    }
+
+    // -----------------------------------------------------------------
+    // Gestion des points à répartir
+    // -----------------------------------------------------------------
+    function updateSkillsPointsDisplay() {
+        const currentPoints = getCurrentCategoryPoints();
+        skillsPointsValueEl.textContent = currentPoints;
+        const hasPoints = currentPoints > 0;
+        const isLocked = skillsState.locksByCategory[skillsState.activeCategoryId];
+
+        skillsPointsMinusEl.disabled = !skillsState.isAdmin || !hasPoints || isLocked;
+        skillsPointsPlusEl.disabled = !skillsState.isAdmin || isLocked;
+        skillsPointsResetEl.disabled = !hasPoints || isLocked;
+
+        const activeCategory = getActiveCategory();
+        if (!activeCategory) return;
+        const allocations = getCategoryAllocations(activeCategory.id);
+
+        skillsListEl.querySelectorAll(".skills-line").forEach((line) => {
+            const nameEl = line.querySelector(".skills-name");
+            const incBtn = line.querySelector(".skill-point-btn:nth-child(3)");
+            const decBtn = line.querySelector(".skill-point-btn:nth-child(1)");
+            if (!nameEl || !incBtn || !decBtn) return;
+            const allocation = allocations[nameEl.textContent] || 0;
+            decBtn.disabled = allocation <= 0 || skillsState.locksByCategory[activeCategory.id];
+            incBtn.disabled = currentPoints <= 0 || skillsState.locksByCategory[activeCategory.id];
+        });
+    }
+
+    skillsPointsPlusEl.addEventListener("click", () => {
+        if (!skillsState.isAdmin) return;
+        const nextValue = Math.min(getCurrentCategoryPoints() + 1, 99);
+        setCurrentCategoryPoints(nextValue);
+        updateSkillsPointsDisplay();
+    });
+
+    skillsPointsMinusEl.addEventListener("click", () => {
+        if (!skillsState.isAdmin) return;
+        const current = getCurrentCategoryPoints();
+        if (current > 0) {
+            setCurrentCategoryPoints(current - 1);
+            updateSkillsPointsDisplay();
+        }
+    });
+
+    skillsPointsResetEl.addEventListener("click", () => {
+        if (skillsState.locksByCategory[skillsState.activeCategoryId]) return;
+        setCurrentCategoryPoints(0);
+        clearAllocations(skillsState.activeCategoryId);
+        renderSkillsCategory(getActiveCategory());
+    });
+
+    function clearAllocations(categoryId) {
+        skillsState.allocationsByCategory[categoryId] = {};
+        saveToStorage(skillsAllocStorageKey, skillsState.allocationsByCategory);
+    }
+
+    // -----------------------------------------------------------------
+    // Validation / verrouillage
+    // -----------------------------------------------------------------
+    skillsConfirmEl.addEventListener("click", () => {
+        const activeCategory = getActiveCategory();
+        if (!activeCategory) return;
+        skillsState.locksByCategory[activeCategory.id] = true;
+        updateLockState(true);
+        renderSkillsCategory(activeCategory);
+        announce(`Points verrouillés pour ${activeCategory.label}`);
+    });
+
+    function updateLockState(isLocked) {
+        skillsConfirmEl.disabled = isLocked;
+        if (isLocked) {
+            skillsConfirmEl.classList.add("is-locked");
+        } else {
+            skillsConfirmEl.classList.remove("is-locked");
+        }
+    }
+
+    function announce(message) {
+        if (!skillsFeedbackEl) return;
+        skillsFeedbackEl.textContent = message;
+    }
+})();

--- a/data.js
+++ b/data.js
@@ -188,3 +188,117 @@ const inventoryData = [
     //   }
 ];
 
+
+// -----------------------------------------------------------------------------
+// Compétences (compétences par catégorie)
+// -----------------------------------------------------------------------------
+window.skillsCategories = [
+    {
+        id: "arts",
+        label: "Arts",
+        icon: { src: "assets/images/Bouton_1_Competences.png", alt: "Arts" },
+        skills: [
+            { name: "Peinture", baseValue: 12, icon: "🖌️" },
+            { name: "Musique", baseValue: 8, icon: "🎵" },
+            { name: "Théâtre", baseValue: 6, icon: "🎭" },
+            { name: "Écriture créative", baseValue: 10, icon: "✍️" },
+            { name: "Danse", baseValue: 5, icon: "💃" }
+        ]
+    },
+    {
+        id: "connaissances",
+        label: "Connaissances",
+        icon: { src: "assets/images/Bouton_2_Competences.png", alt: "Connaissances" },
+        skills: [
+            { name: "Histoire", baseValue: 9, icon: "📜" },
+            { name: "Arcane & Théorie", baseValue: 7, icon: "🔮" },
+            { name: "Linguistique", baseValue: 11, icon: "🗣️" },
+            { name: "Religion & Mythes", baseValue: 5, icon: "⛪" },
+            { name: "Investigation", baseValue: 8, icon: "🔍" }
+        ]
+    },
+    {
+        id: "combat",
+        label: "Combat",
+        icon: { src: "assets/images/Bouton_3_Competences.png", alt: "Combat" },
+        skills: [
+            { name: "Maniement des armes", baseValue: 13, icon: "🗡️" },
+            { name: "Parade", baseValue: 7, icon: "🛡️" },
+            { name: "Esquive", baseValue: 10, icon: "💨" },
+            { name: "Résistance physique", baseValue: 6, icon: "💪" },
+            { name: "Tactique de groupe", baseValue: 4, icon: "👥" }
+        ]
+    },
+    {
+        id: "pouvoirs",
+        label: "Pouvoirs",
+        icon: { src: "assets/images/Bouton_4_Competences.png", alt: "Pouvoirs" },
+        skills: [
+            { name: "Contrôle d'Alice", baseValue: 15, icon: "🌟" },
+            { name: "Synchronisation Meister", baseValue: 9, icon: "🔗" },
+            { name: "Maîtrise d'arme", baseValue: 11, icon: "⚡" },
+            { name: "Déchaînement contrôlé", baseValue: 5, icon: "💥" },
+            { name: "Stabilité mentale", baseValue: 7, icon: "🧠" }
+        ]
+    },
+    {
+        id: "social",
+        label: "Social",
+        icon: { src: "assets/images/Bouton_5_Competences.png", alt: "Social" },
+        skills: [
+            { name: "Persuasion", baseValue: 10, icon: "🎯" },
+            { name: "Intimidation", baseValue: 6, icon: "😠" },
+            { name: "Empathie", baseValue: 9, icon: "❤️" },
+            { name: "Négociation", baseValue: 7, icon: "🤝" },
+            { name: "Tromperie", baseValue: 4, icon: "🎭" }
+        ]
+    },
+    {
+        id: "artisanat",
+        label: "Artisanat",
+        icon: { src: "assets/images/Bouton_6_Competences.png", alt: "Artisanat" },
+        skills: [
+            { name: "Forge & Métallurgie", baseValue: 6, icon: "⚒️" },
+            { name: "Alchimie", baseValue: 8, icon: "⚗️" },
+            { name: "Ingénierie", baseValue: 5, icon: "⚙️" },
+            { name: "Couture & Tissage", baseValue: 7, icon: "🧵" },
+            { name: "Cuisine", baseValue: 9, icon: "🍳" }
+        ]
+    },
+    {
+        id: "nature",
+        label: "Nature",
+        icon: { src: "assets/images/Bouton_7_Competences.png", alt: "Nature" },
+        skills: [
+            { name: "Orientation", baseValue: 7, icon: "🧭" },
+            { name: "Pistage", baseValue: 6, icon: "👣" },
+            { name: "Herboristerie", baseValue: 8, icon: "🌿" },
+            { name: "Survie en milieu hostile", baseValue: 9, icon: "🏕️" },
+            { name: "Discrétion", baseValue: 5, icon: "🥷" }
+        ]
+    },
+    {
+        id: "physique",
+        label: "Physique",
+        icon: { src: "assets/images/Bouton_8_Competences.png", alt: "Physique" },
+        skills: [
+            { name: "Force brute", baseValue: 10, icon: "🏋️" },
+            { name: "Agilité", baseValue: 11, icon: "🤸" },
+            { name: "Endurance", baseValue: 9, icon: "🏃" },
+            { name: "Réflexes", baseValue: 8, icon: "⚡" },
+            { name: "Athlétisme", baseValue: 7, icon: "🏅" }
+        ]
+    },
+    {
+        id: "reputation",
+        label: "Réputation",
+        icon: { src: "assets/images/Bouton_9_Competences.png", alt: "Réputation" },
+        skills: [
+            { name: "Renommée", baseValue: 6, icon: "⭐" },
+            { name: "Contacts", baseValue: 8, icon: "📞" },
+            { name: "Marchandage", baseValue: 10, icon: "💰" },
+            { name: "Crédit social", baseValue: 5, icon: "📈" },
+            { name: "Influence politique", baseValue: 4, icon: "🏛️" }
+        ]
+    }
+];

--- a/docs/competences-plan.md
+++ b/docs/competences-plan.md
@@ -1,0 +1,69 @@
+# Plan d'amélioration ciblé — competences.html (Priorité 4 > 1 > 3 > 5, priorité 2 mise de côté)
+
+## État d'avancement rapide
+- ✅ P4 — Conserver la structure existante (aucun nouveau dossier créé) et rester KISS.
+- ✅ P4 — Extraire les données `skillsCategories` vers `data.js` et la logique JS vers `competences.js` avec `<script defer>`.
+- ⬜ P4 — Ajouter `<main>` + conteneur `role="navigation"` harmonisés sur toutes les pages.
+- ✅ P1 — Externaliser le bloc `<script>` de `competences.html` vers `competences.js`.
+- ✅ P1 — Accessibilité/clavier : rôles tablist/tab, aria-selected, navigation fléchée, aria-live sur le compteur.
+- ✅ P1 — États de chargement/erreur minimalistes (placeholder "Chargement..." et fallback vide).
+- ✅ P1 — Points à répartir : règles admin/joueur, +/− par compétence selon compteur, bouton de validation/lock.
+- ✅ P1 — Persistance simple par onglet + bouton de réinitialisation dédié (localStorage, reset) sans sur-ingénierie.
+- ✅ P3 — Lien de retour vers `categories.html` et nettoyage DOM (icônes non inline, escapeHtml si nécessaire).
+- ⬜ P5 — Rappel navigateurs modernes uniquement (pas encore rappelé dans le code).
+- ⬜ P2 — Nice-to-have (micro-interactions, recherche live, etc.) volontairement non traités.
+
+## Rappel de priorisation
+- **P4** : Points transverses simples appliqués en premier (DRY/KISS)
+- **P1** : Améliorations spécifiques à `competences.html`
+- **P3** : Quick wins supplémentaires
+- **P5** : Compatibilité navigateurs modernes (rappel seulement)
+- **P2** : UX nice-to-have **mis de côté** (voir section dédiée en fin de document)
+
+## P4 — Points transverses (appliquer avant le reste)
+- **Conserver la structure de fichiers actuelle (KISS)**
+  - Pas de création de nouveaux dossiers (`assets/js`, `assets/css`, etc.) pour cette phase afin de préserver les références existantes.
+  - Si extraction nécessaire, rester dans les fichiers actuels (`data.js` pour les données, un seul nouveau fichier JS à la racine si indispensable) et garder les balises `<script>` natives.
+- **Extraire uniquement le minimum utile**
+  - Déplacer `skillsCategories` (lignes ~427-512 et suivantes) vers `data.js` sous `window.skillsCategories` et le charger avant le script dédié à la page (toujours via `<script src="data.js" defer></script>`).
+  - Sortir la logique JS (lignes ~539-658) dans un simple `competences.js` à la racine, chargé avec `defer` (pas de `type="module"` pour éviter tout changement de scope ou de chemin).
+- **Structure sémantique minimale partagée**
+  - Ajouter `<main>` et un conteneur `role="navigation"` cohérents sur toutes les pages en reprenant le pattern déjà présent dans `competences.html` (lignes 400-419) afin d’harmoniser les landmarks.
+
+## P1 — Améliorations ciblées competences.html
+- **Scripts externalisés et chargés proprement**
+  - Remplacer le bloc `<script>` inline (lignes ~423-659) par l’inclusion de `competences.js` (à la racine) avec `defer` pour ne pas bloquer le rendu, sans déplacer d’autres ressources.
+- **Accessibilité & clavier**
+  - Ajouter gestion clavier sur onglets : `keydown` flèches gauche/droite et `Home/End` pour naviguer entre boutons `.skills-tab-btn`, focus visible et réordonnancement de l’activation via `space/enter` (sur les éléments créés dans `renderSkillsTabs`).
+  - Définir `role="tablist"` sur `#skillsTabs`, `role="tab"` sur les boutons et `aria-selected` synchronisé dans `renderSkillsTabs` / `setActiveSkillsCategory`.
+  - Encapsuler la liste dans `<section aria-labelledby="skillsCategoryTitle">` (déjà présent) et ajouter `role="status"` ou `aria-live="polite"` sur le conteneur de points (lignes 404-413) pour annoncer les changements.
+- **États de chargement / erreurs minimalistes (YAGNI)**
+  - Avant le rendu initial, afficher un placeholder `li` "Chargement..."; retirer après `renderSkillsCategory`.
+  - Entourer les lectures de `skillsCategories` d’un guard simple (fallback message "Aucune compétence" si vide) sans ajouter de state management complexe.
+- **Points à répartir : logique admin / joueur**
+  - Admin uniquement : garder les boutons `+` / `−` du compteur global "points à répartir" pour l’allocation initiale (boutons non rendus côté joueur).
+  - Joueur : afficher le compteur "points à répartir" (en lecture seule) par onglet, sans les boutons `+` / `−` globaux.
+  - Par catégorie (par ex. Arts, Connaissance…) : afficher des `+` / `−` à côté de chaque compétence uniquement si le compteur de la catégorie > 0 ; griser/désactiver sinon (classe `is-disabled`, `aria-disabled="true"`).
+  - Lorsque le joueur répartit ses points dans une catégorie, décrémenter le compteur propre à l’onglet ; si le compteur atteint 0, désactiver les `+` ; empêcher toute baisse sous 0 avec garde dans le gestionnaire `onDecrement`.
+  - Ajouter un bouton de confirmation/validation par onglet (ex. "Valider mes points") qui :
+    - bloque les `+` / `−` après validation (classe `is-locked`),
+    - déclenche un message de feedback (`role="status"`, aria-live) confirmant l’enregistrement,
+    - reste KISS : aucune persistance pour l’instant, simple verrouillage en mémoire.
+- **Pas d’animations supplémentaires**
+  - Ne pas introduire de nouvelles animations ou transitions ; conserver la rapidité d’action. Retirer/ignorer la mention `prefers-reduced-motion` de cette phase.
+
+## P3 — Quick wins supplémentaires
+- **Navigation cohérente**
+  - Ajouter dans `competences.html` un lien de retour vers `categories.html` dans l’entête pour sortir l’état d’orphelin (KISS : un simple `<a>` stylé).
+- **Nettoyage DOM**
+  - Remplacer les images inline d’icônes (ex : `icon: '<img ...>'`) par des références à des classes utilitaires ou emojis stockés dans les données pour éviter l’injection HTML dans `innerHTML`.
+- **Protection XSS minimale**
+  - Si un utilitaire commun devient nécessaire, l’ajouter dans le même fichier JS (pas de nouveau dossier) avec `escapeHtml` pour la génération des labels.
+
+## P5 — Compatibilité (rappel)
+- Navigateurs modernes uniquement ; pas de transpilation ni polyfills. Conserver les API DOM standards, privilégier `classList`, `dataset`, `aria-*`.
+
+## P2 — Nice-to-have UX (non planifiés dans cette phase)
+- Micro-interactions sur les boutons d’onglet (hover/active) et feedback sonore optionnel (à repousser pour ne pas casser la rapidité d’action).
+- Filtres ou recherche live dans les compétences (à envisager seulement si besoin utilisateur confirmé).
+- Persistance des points à répartir dans `localStorage` avec un bouton "Réinitialiser" dédié.


### PR DESCRIPTION
## Summary
- externalize competences data to data.js and move page logic into a new competences.js with keyboard/ARIA support
- add per-skill allocation controls with category-level point tracking, validation lock, and loading/empty placeholders
- update competences plan checklist to reflect completed items and add link back to categories

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693970f331f88327adb859af6bafeadf)