### PR TITLE
Increase skill icon sizes by 50%

### DIFF
--- a/competences.html
+++ b/competences.html
@@ -105,8 +105,8 @@
         }
 
         .skills-tab-circle {
-            width: 69px;
-            height: 69px;
+            width: calc(69px * 1.5);
+            height: calc(69px * 1.5);
             display: block;
             transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
         }
@@ -298,8 +298,8 @@
         }
 
         .skills-icon {
-            width: 28px;
-            height: 28px;
+            width: calc(28px * 1.5);
+            height: calc(28px * 1.5);
             border-radius: 6px;
             margin-right: var(--space-3);
             background:


### PR DESCRIPTION
## Summary
- enlarge category tab icons by 50% to highlight skill hearts
- enlarge inline skill icons by 50% while preserving layout and aspect ratios

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939d0beb06c8327a66d837bb0b47591)